### PR TITLE
Avoid saving cancelled task edits

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,9 @@ use crate::recurrence::{
 };
 use crate::task::Task;
 use crate::task::TaskData;
-use crate::task_edit::{render_task_edit_popup, TaskEditState};
+use crate::task_edit::{
+    handle_task_edit_key, render_task_edit_popup, TaskEditAction, TaskEditState,
+};
 use crate::undo::{Operation, UndoStack};
 use crate::utils::days_in_month;
 use commands::get_command_registry;
@@ -359,11 +361,16 @@ impl App {
             }
             AppMode::TaskEdit(state) => {
                 let mut new_state = state.clone();
-                if self.handle_task_edit_key(key, &mut new_state)? {
-                    self.save_task_edit_state(new_state)?;
-                    self.mode = AppMode::Normal;
-                } else {
-                    self.mode = AppMode::TaskEdit(new_state);
+                match handle_task_edit_key(&self.config, key, &mut new_state) {
+                    TaskEditAction::Continue => self.mode = AppMode::TaskEdit(new_state),
+                    TaskEditAction::Save => {
+                        self.save_task_edit_state(new_state)?;
+                        self.mode = AppMode::Normal;
+                    }
+                    TaskEditAction::Cancel => {
+                        self.pending_insert_order = None;
+                        self.mode = AppMode::Normal;
+                    }
                 }
             }
             AppMode::RecurrencePreview(state) => {
@@ -846,31 +853,6 @@ impl App {
             self.scramble_mode = !self.scramble_mode;
         }
         Ok(())
-    }
-
-    fn handle_task_edit_key(
-        &mut self,
-        key: crossterm::event::KeyEvent,
-        state: &mut TaskEditState,
-    ) -> Result<bool> {
-        if key.kind == KeyEventKind::Press {
-            if self.config.cancel_edit.matches(key.code, key.modifiers) {
-                // Cancel edit
-                return Ok(true);
-            } else if self.config.save_task.matches(key.code, key.modifiers) {
-                // Save task
-                if !state.title.trim().is_empty() {
-                    return Ok(true);
-                }
-            } else if self.config.switch_field.matches(key.code, key.modifiers) {
-                state.switch_field();
-            } else if self.config.backspace.matches(key.code, key.modifiers) {
-                state.remove_char();
-            } else if let KeyCode::Char(ch) = key.code {
-                state.add_char(ch);
-            }
-        }
-        Ok(false)
     }
 
     fn handle_command_mode_key(

--- a/src/task_edit.rs
+++ b/src/task_edit.rs
@@ -1,5 +1,7 @@
+use crate::config::Config;
 use crate::task::Task;
 use chrono::{NaiveDate, TimeZone, Utc};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
 use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::{Modifier, Style},
@@ -25,6 +27,44 @@ pub struct TaskEditState {
 pub enum EditingField {
     Title,
     Content,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskEditAction {
+    Continue,
+    Save,
+    Cancel,
+}
+
+pub fn handle_task_edit_key(
+    config: &Config,
+    key: KeyEvent,
+    state: &mut TaskEditState,
+) -> TaskEditAction {
+    if key.kind != KeyEventKind::Press {
+        return TaskEditAction::Continue;
+    }
+
+    if config.cancel_edit.matches(key.code, key.modifiers) {
+        TaskEditAction::Cancel
+    } else if config.save_task.matches(key.code, key.modifiers) {
+        if state.title.trim().is_empty() {
+            TaskEditAction::Continue
+        } else {
+            TaskEditAction::Save
+        }
+    } else if config.switch_field.matches(key.code, key.modifiers) {
+        state.switch_field();
+        TaskEditAction::Continue
+    } else if config.backspace.matches(key.code, key.modifiers) {
+        state.remove_char();
+        TaskEditAction::Continue
+    } else if let KeyCode::Char(ch) = key.code {
+        state.add_char(ch);
+        TaskEditAction::Continue
+    } else {
+        TaskEditAction::Continue
+    }
 }
 
 impl TaskEditState {
@@ -277,4 +317,49 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
         Constraint::Percentage((100 - percent_x) / 2),
     ])
     .split(popup_layout[1])[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn state() -> TaskEditState {
+        TaskEditState::new_task(NaiveDate::from_ymd_opt(2026, 7, 11).unwrap())
+    }
+
+    #[test]
+    fn escape_cancels_without_modifying_the_state() {
+        let config = Config::from_config_file(None);
+        let mut state = state();
+        state.title = "Keep me unchanged".to_string();
+
+        let action = handle_task_edit_key(
+            &config,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            &mut state,
+        );
+
+        assert_eq!(action, TaskEditAction::Cancel);
+        assert_eq!(state.title, "Keep me unchanged");
+    }
+
+    #[test]
+    fn enter_only_saves_a_non_empty_title() {
+        let config = Config::from_config_file(None);
+        let mut empty_state = state();
+        let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+
+        assert_eq!(
+            handle_task_edit_key(&config, enter, &mut empty_state),
+            TaskEditAction::Continue
+        );
+
+        let mut titled_state = state();
+        titled_state.title = "Task".to_string();
+        assert_eq!(
+            handle_task_edit_key(&config, enter, &mut titled_state),
+            TaskEditAction::Save
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- distinguish task edit continuation, save, and cancel actions
- return to normal mode without saving when the edit is cancelled
- clear a pending `o`/`O` insertion position when its edit is cancelled
- cover Escape and Enter behavior with focused unit tests

## Why

Task editing previously returned the same boolean for both Enter and Escape. The caller treated either result as a completed save, so pressing `i` followed by Escape created a blank task. This addresses the task-edit cancellation behavior described in #32 without changing recurrence generation.

## Validation

- `cargo test --locked` (7 passed)
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features`
- `cargo fmt -- --check`
- manual TUI: `i` then Escape leaves no data file or task
- manual TUI: `o` then Escape followed by a normal insert creates one task at order 1
